### PR TITLE
Fix webpack bundle error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  entry: './lib/js/src/client/app.js',
+  entry: './lib/js/src/client/App.js',
   output: {
     path: __dirname +'/public',
     filename: 'bundle.js',


### PR DESCRIPTION
Hi,

I got this error when trying to run `yarn bundle`:

```
ERROR in Entry module not found: Error: Can't resolve './lib/js/src/client/app.js' in <...>
```

I'm guessing it might be because my filesystem is case-sensitive?